### PR TITLE
cysignals: cimports instead of deprecated .pxi files

### DIFF
--- a/cypari2/closure.pyx
+++ b/cypari2/closure.pyx
@@ -33,7 +33,7 @@ Examples:
 
 from __future__ import absolute_import, division, print_function
 
-include "cysignals/signals.pxi"
+from cysignals.signals cimport sig_on, sig_off, sig_block, sig_unblock, sig_error
 
 from cpython.tuple cimport *
 from cpython.object cimport PyObject_Call

--- a/cypari2/convert.pyx
+++ b/cypari2/convert.pyx
@@ -41,7 +41,7 @@ some bit shuffling.
 
 from __future__ import absolute_import, division, print_function
 
-include "cysignals/signals.pxi"
+from cysignals.signals cimport sig_on, sig_off, sig_error
 
 from cpython.object cimport Py_SIZE
 from cpython.int cimport PyInt_AS_LONG

--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -68,8 +68,8 @@ from cpython.float cimport PyFloat_AS_DOUBLE
 from cpython.complex cimport PyComplex_RealAsDouble, PyComplex_ImagAsDouble
 from cpython.object cimport Py_EQ, Py_NE, Py_LE, Py_GE, Py_LT, Py_GT
 
-include "cysignals/memory.pxi"
-include "cysignals/signals.pxi"
+from cysignals.memory cimport sig_free, check_malloc
+from cysignals.signals cimport sig_check, sig_on, sig_off, sig_block, sig_unblock
 
 from .paridecl cimport *
 from .string_utils cimport to_string, to_bytes
@@ -1592,7 +1592,7 @@ cdef class Gen(Gen_auto):
             return "0"
         lx = lgefint(x) - 2  # number of words
         size = lx * 4 * sizeof(long)
-        s = <char *>sig_malloc(size+3) # 1 char for sign, 1 char for 0, 1 char for '\0'
+        s = <char *>check_malloc(size+3) # 1 char for sign, 1 char for 0, 1 char for '\0'
         sp = s + size + 3
         sp[0] = 0
         xp = int_LSW(x)
@@ -1635,7 +1635,7 @@ cdef class Gen(Gen_auto):
             return "0x0"
         lx = lgefint(x) - 2  # number of words
         size = lx*2*sizeof(long)
-        s = <char *>sig_malloc(size+4) # 1 char for sign, 2 chars for 0x, 1 char for '\0'
+        s = <char *>check_malloc(size+4) # 1 char for sign, 2 chars for 0x, 1 char for '\0'
         sp = s + size + 4
         sp[0] = 0
         xp = int_LSW(x)

--- a/cypari2/handle_error.pyx
+++ b/cypari2/handle_error.pyx
@@ -23,9 +23,9 @@ AUTHORS:
 
 from __future__ import absolute_import, division, print_function
 
-include "cysignals/signals.pxi"
-
 from cpython cimport PyErr_Occurred
+
+from cysignals.signals cimport sig_block, sig_unblock, sig_error
 
 from .paridecl cimport *
 from .paripriv cimport *

--- a/cypari2/pari_instance.pyx
+++ b/cypari2/pari_instance.pyx
@@ -227,11 +227,11 @@ test
 
 from __future__ import absolute_import, division
 
-include "cysignals/signals.pxi"
-
 import sys
 from libc.stdio cimport *
 cimport cython
+
+from cysignals.signals cimport sig_check, sig_on, sig_off
 
 from .string_utils cimport to_string, to_bytes
 from .paridecl cimport *

--- a/cypari2/stack.pyx
+++ b/cypari2/stack.pyx
@@ -18,11 +18,10 @@ so it is not included in the documentation.
 
 from __future__ import absolute_import, division, print_function
 
-include "cysignals/signals.pxi"
-include "cysignals/memory.pxi"
-
 cdef extern from *:
     int sig_on_count "cysigs.sig_on_count"
+from cysignals.signals cimport sig_off
+from cysignals.memory cimport check_malloc
 
 from .paridecl cimport pari_mainstack, avma, paristack_setsize, gsizebyte, gcopy_avma, gnil
 

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ class build_ext(_build_ext):
 
         self.distribution.ext_modules[:] = cythonize(
             self.distribution.ext_modules,
-            compiler_directives=self.directives,
-            include_path=sys.path)
+            compiler_directives=self.directives)
 
         _build_ext.finalize_options(self)
 


### PR DESCRIPTION
As a consequence, `cypari2` now builds without warnings, except for some `-Wmaybe-uninitialized` false positives.