### PR TITLE
to_bytes and to_unicode: convert if needed

### DIFF
--- a/cypari2/string_utils.pyx
+++ b/cypari2/string_utils.pyx
@@ -6,6 +6,7 @@ Conversion functions for bytes/unicode
 import sys
 encoding = sys.getfilesystemencoding()
 
+
 cpdef bytes to_bytes(s):
     """
     Converts bytes and unicode ``s`` to bytes.
@@ -16,17 +17,26 @@ cpdef bytes to_bytes(s):
     >>> s1 = to_bytes(b'hello')
     >>> s2 = to_bytes('hello')
     >>> s3 = to_bytes(u'hello')
-    >>> type(s1) == type(s2) == type(s3) == bytes
+    >>> type(s1) is type(s2) is type(s3) is bytes
     True
     >>> s1 == s2 == s3 == b'hello'
     True
+
+    >>> type(to_bytes(1234)) is bytes
+    True
+    >>> int(to_bytes(1234))
+    1234
     """
-    if isinstance(s, bytes):
-        return <bytes> s
-    elif isinstance(s, unicode):
-        return (<unicode> s).encode(encoding)
-    else:
-        raise TypeError
+    cdef int convert
+    for convert in range(2):
+        if convert:
+            s = str(s)
+        if isinstance(s, bytes):
+            return <bytes> s
+        elif isinstance(s, unicode):
+            return (<unicode> s).encode(encoding)
+    raise AssertionError(f"str() returned {type(s)}")
+
 
 cpdef unicode to_unicode(s):
     r"""
@@ -38,17 +48,18 @@ cpdef unicode to_unicode(s):
     >>> s1 = to_unicode(b'hello')
     >>> s2 = to_unicode('hello')
     >>> s3 = to_unicode(u'hello')
-    >>> import sys
-    >>> u_type = (unicode if sys.version_info.major <= 2 else str)
-    >>> type(s1) == type(s2) == type(s3) == u_type
+    >>> type(s1) is type(s2) is type(s3) is type(u"")
     True
     >>> s1 == s2 == s3 == u'hello'
+    True
+
+    >>> print(to_unicode(1234))
+    1234
+    >>> type(to_unicode(1234)) is type(u"")
     True
     """
     if isinstance(s, bytes):
         return (<bytes> s).decode(encoding)
     elif isinstance(s, unicode):
         return <unicode> s
-    else:
-        raise TypeError
-
+    return unicode(s)


### PR DESCRIPTION
The old pre-Python-3 version of `cypari2` actually did a conversion `str(s)` if needed. The new version requires that `s` is already a `bytes` or `unicode` object. This causes several regressions in SageMath.