### PR TITLE
Use Unicode everywhere for autogenerating code

### DIFF
--- a/autogen/args.py
+++ b/autogen/args.py
@@ -12,6 +12,8 @@ Arguments for PARI calls
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
+from __future__ import unicode_literals
+
 # Some replacements for reserved words
 replacements = {'char': 'character'}
 

--- a/autogen/generator.py
+++ b/autogen/generator.py
@@ -13,8 +13,8 @@ Auto-generate methods for PARI functions.
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import absolute_import, print_function
-import os, re, sys
+from __future__ import absolute_import, print_function, unicode_literals
+import os, re, sys, io
 
 from .args import PariArgumentGEN, PariInstanceArgument
 from .parser import read_pari_desc, parse_prototype
@@ -284,9 +284,6 @@ class PariFunctionGenerator(object):
           given whenever this method is called
         """
         doc = doc.replace("\n", "\n        ")  # Indent doc
-        # doc is unicode, we want str => need to convert on Python 2
-        if not isinstance(doc, str):
-            doc = doc.encode("utf-8")
 
         protoargs = ", ".join(a.prototype_code() for a in args)
         callargs = ", ".join(a.call_code() for a in cargs)
@@ -320,16 +317,11 @@ class PariFunctionGenerator(object):
         D = sorted(D.values(), key=lambda d: d['function'])
         sys.stdout.write("Generating PARI functions:")
 
-        # Stupid Python 3 forces us to specify an encoding
-        if "encoding" in open.__doc__:
-            kwds = dict(mode="wt", encoding="utf-8")
-        else:
-            kwds = dict(mode="wt")
-        self.gen_file = open(self.gen_filename + '.tmp', **kwds)
+        self.gen_file = io.open(self.gen_filename + '.tmp', 'w', encoding='utf-8')
         self.gen_file.write(gen_banner)
-        self.instance_file = open(self.instance_filename + '.tmp', **kwds)
+        self.instance_file = io.open(self.instance_filename + '.tmp', 'w', encoding='utf-8')
         self.instance_file.write(instance_banner)
-        self.decl_file = open(self.decl_filename + '.tmp', **kwds)
+        self.decl_file = io.open(self.decl_filename + '.tmp', 'w', encoding='utf-8')
         self.decl_file.write(decl_banner)
 
         for v in D:

--- a/autogen/parser.py
+++ b/autogen/parser.py
@@ -12,9 +12,9 @@ Read and parse the file pari.desc
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import os, re
+import os, re, io
 
 from .args import pari_arg_types
 from .ret import pari_ret_types
@@ -44,7 +44,8 @@ def read_pari_desc():
         ...   'section': 'transcendental'}
         True
     """
-    with open(os.path.join(pari_share(), b'pari.desc')) as f:
+    pari_desc = os.path.join(pari_share(), b'pari.desc')
+    with io.open(pari_desc, encoding="utf-8") as f:
         lines = f.readlines()
 
     n = 0
@@ -100,7 +101,7 @@ def parse_prototype(proto, help, initial_args=[]):
         >>> help = 'qfbred(x,{flag=0},{d},{isd},{sd})'
         >>> parse_prototype(proto, help)
         ([GEN x, long flag=0, GEN d=NULL, GEN isd=NULL, GEN sd=NULL], GEN)
-        >>> parse_prototype("lp", "foo()", ["TEST"])
+        >>> parse_prototype("lp", "foo()", [str("TEST")])
         (['TEST', prec precision=0], long)
     """
     # Use the help string just for the argument names.

--- a/autogen/paths.py
+++ b/autogen/paths.py
@@ -12,7 +12,7 @@ Find out installation paths of PARI/GP
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import os
 from glob import glob

--- a/autogen/ret.py
+++ b/autogen/ret.py
@@ -12,6 +12,8 @@ Return types for PARI calls
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
+from __future__ import unicode_literals
+
 class PariReturn(object):
     """
     This class represents the return value of a PARI call.


### PR DESCRIPTION
As suggested by @embray, do the auto-generation of the code the "Python 3" way, using Unicode everywhere.