### PR TITLE
Fix failing tests on Cygwin

### DIFF
--- a/cypari2/pari_instance.pyx
+++ b/cypari2/pari_instance.pyx
@@ -956,13 +956,13 @@ cdef class Pari(Pari_auto):
         >>> import cypari2
         >>> pari = cypari2.Pari()
         >>> pari.allocatemem(10**7)
-        PARI stack size set to 10000000 bytes, maximum size set to 10002432
+        PARI stack size set to 10000000 bytes, maximum size set to 100...
         >>> pari.allocatemem()  # Double the current size
-        PARI stack size set to 20000000 bytes, maximum size set to 20000768
+        PARI stack size set to 20000000 bytes, maximum size set to 200...
         >>> pari.stacksize()
         20000000
         >>> pari.allocatemem(10**6)
-        PARI stack size set to 1000000 bytes, maximum size set to 20000768
+        PARI stack size set to 1000000 bytes, maximum size set to 200...
 
         The following computation will automatically increase the PARI
         stack size:


### PR DESCRIPTION
These three doctests fail on Cygwin, because the actual size for vsize depends on `PARI_STACK_ALIGNMENT` which in turn depends on `sysconf(_SC_PAGESIZE)` which is different on Cygwin than on Linux, for example.

This fix is just a hack though.  It might be better API-wise if `Pari.allocatemem` just returned the set stack size/maxsize as a tuple, and didn't print anything (better left up to the application).  The doctest could make a more precise comparison if desired.