### PR TITLE
Convert pari_share() to str

### DIFF
--- a/autogen/__init__.py
+++ b/autogen/__init__.py
@@ -10,7 +10,7 @@ from .paths import pari_share
 
 def rebuild(force=False):
     pari_module_path = 'cypari2'
-    src_files = [join(pari_share(), b'pari.desc')] + \
+    src_files = [join(pari_share(), 'pari.desc')] + \
                  glob.glob(join('autogen', '*.py'))
     gen_files = [join(pari_module_path, 'auto_paridecl.pxd'),
                  join(pari_module_path, 'auto_gen.pxi')]

--- a/autogen/parser.py
+++ b/autogen/parser.py
@@ -44,7 +44,7 @@ def read_pari_desc():
         ...   'section': 'transcendental'}
         True
     """
-    pari_desc = os.path.join(pari_share(), b'pari.desc')
+    pari_desc = os.path.join(pari_share(), 'pari.desc')
     with io.open(pari_desc, encoding="utf-8") as f:
         lines = f.readlines()
 

--- a/autogen/paths.py
+++ b/autogen/paths.py
@@ -20,7 +20,7 @@ from distutils.spawn import find_executable
 
 
 # find_executable() returns None if nothing was found
-gppath = find_executable("gp") or ""
+gppath = find_executable("gp")
 if gppath is None:
     # This almost certainly won't work, but we need to put something here
     prefix = "."
@@ -36,7 +36,7 @@ def pari_share():
     EXAMPLES::
 
         >>> from autogen.parser import pari_share
-        >>> pari_share().endswith(b'/share/pari')
+        >>> pari_share().endswith('/share/pari')
         True
     """
     from subprocess import Popen, PIPE
@@ -44,6 +44,10 @@ def pari_share():
         raise EnvironmentError("cannot find an installation of PARI/GP: make sure that the 'gp' program is in your $PATH")
     gp = Popen([gppath, "-f", "-q"], stdin=PIPE, stdout=PIPE)
     out = gp.communicate(b"print(default(datadir))")[0]
+    # Convert out to str if needed
+    if not isinstance(out, str):
+        from sys import getfilesystemencoding
+        out = out.decode(getfilesystemencoding(), "surrogateescape")
     datadir = out.strip()
     if not os.path.isdir(datadir):
         # As a fallback, try a path relative to the prefix


### PR DESCRIPTION
Always use `str` instead of `bytes` for filenames.

@embray 