### PR TITLE
[WIP] Do not confuse optional data dir with pari_share

### DIFF
--- a/autogen/paths.py
+++ b/autogen/paths.py
@@ -39,22 +39,10 @@ def pari_share():
         >>> pari_share().endswith('/share/pari')
         True
     """
-    from subprocess import Popen, PIPE
-    if not gppath:
-        raise EnvironmentError("cannot find an installation of PARI/GP: make sure that the 'gp' program is in your $PATH")
-    gp = Popen([gppath, "-f", "-q"], stdin=PIPE, stdout=PIPE)
-    out = gp.communicate(b"print(default(datadir))")[0]
-    # Convert out to str if needed
-    if not isinstance(out, str):
-        from sys import getfilesystemencoding
-        out = out.decode(getfilesystemencoding(), "surrogateescape")
-    datadir = out.strip()
-    if not os.path.isdir(datadir):
-        # As a fallback, try a path relative to the prefix
-        datadir = os.path.join(prefix, "share", "pari")
-        if not os.path.isdir(datadir):
-            raise EnvironmentError("PARI data directory {!r} does not exist".format(datadir))
-    return datadir
+    sharedir = os.path.join(prefix, "share", "pari")
+    if not os.path.isdir(sharedir):
+        raise EnvironmentError("PARI share directory {!r} does not exist".format(sharedir))
+    return sharedir
 
 
 def include_dirs():


### PR DESCRIPTION
Related to the discussion in https://trac.sagemath.org/ticket/26025.

I have not yet tested it, because I would like feedback first. `pari_data` is not actually needed anywhere, so should I just delete the whole datadir detection code?